### PR TITLE
Avoid detecting changes in destination settings coming from remote

### DIFF
--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -567,14 +567,14 @@ func (r *destinationResource) Create(ctx context.Context, req resource.CreateReq
 
 // Read refreshes the Terraform state with the latest data.
 func (r *destinationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var config models.DestinationState
-	diags := req.State.Get(ctx, &config)
+	var previousState models.DestinationState
+	diags := req.State.Get(ctx, &previousState)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	out, _, err := r.client.DestinationsApi.GetDestination(r.authContext, config.ID.ValueString()).Execute()
+	out, _, err := r.client.DestinationsApi.GetDestination(r.authContext, previousState.ID.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Destination",
@@ -596,7 +596,9 @@ func (r *destinationResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// This is to satisfy terraform requirements that the returned fields must match the input ones because new settings can be generated in the response
-	state.Settings = config.Settings
+	if !previousState.Settings.IsNull() && !previousState.Settings.IsUnknown() {
+		state.Settings = previousState.Settings
+	}
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/destination_resource_test.go
+++ b/internal/provider/destination_resource_test.go
@@ -384,7 +384,8 @@ func TestAccDestinationResource(t *testing.T) {
 						})
 					}
 				`,
-				ImportState: true,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
Any changes in destination settings coming from remote would be detected and marked as drift. 

To avoid that, we are setting the state as the plan state, and only changes coming from the configuration will be marked as drift from now on.