### PR TITLE
Handle nil response from SDK

### DIFF
--- a/internal/provider/destination_data_source.go
+++ b/internal/provider/destination_data_source.go
@@ -79,7 +79,7 @@ func (d *destinationDataSource) Read(ctx context.Context, req datasource.ReadReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Destination",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/destination_metadata_data_source.go
+++ b/internal/provider/destination_metadata_data_source.go
@@ -399,7 +399,7 @@ func (d *destinationMetadataDataSource) Read(ctx context.Context, req datasource
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Source metadata",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -538,7 +538,7 @@ func (r *destinationResource) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Destination",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -579,7 +579,7 @@ func (r *destinationResource) Read(ctx context.Context, req resource.ReadRequest
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Destination",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -636,7 +636,7 @@ func (r *destinationResource) Update(ctx context.Context, req resource.UpdateReq
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Destination",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -677,7 +677,7 @@ func (r *destinationResource) Delete(ctx context.Context, req resource.DeleteReq
 	_, body, err := r.client.DestinationsApi.DeleteDestination(r.authContext, state.ID.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error deleting Destination", "Could not delete Destination, unexpected error: "+getError(err, body.Body),
+			"Error deleting Destination", "Could not delete Destination, unexpected error: "+getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -121,7 +121,7 @@ func (r *labelResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create a label",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -156,7 +156,7 @@ func (r *labelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Labels",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -203,7 +203,7 @@ func (r *labelResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	_, body, err := r.client.LabelsApi.DeleteLabel(r.authContext, state.Key.ValueString(), state.Value.ValueString()).Execute()
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Deleting a Label", "Could not delete a label, unexpected error: "+getError(err, body.Body),
+			"Error Deleting a Label", "Could not delete a label, unexpected error: "+getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/source_data_source.go
+++ b/internal/provider/source_data_source.go
@@ -202,7 +202,7 @@ func (d *sourceDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/source_metadata_data_source.go
+++ b/internal/provider/source_metadata_data_source.go
@@ -51,7 +51,7 @@ func (d *sourceMetadataDataSource) Read(ctx context.Context, req datasource.Read
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Source metadata",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -265,7 +265,7 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -280,7 +280,7 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to create Source",
-				getError(err, body.Body),
+				getError(err, body),
 			)
 			return
 		}
@@ -321,7 +321,7 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -378,7 +378,7 @@ func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -399,7 +399,7 @@ func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -437,7 +437,7 @@ func (r *sourceResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Source",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/source_warehouse_connection_resource.go
+++ b/internal/provider/source_warehouse_connection_resource.go
@@ -70,7 +70,7 @@ func (r *sourceWarehouseConnectionResource) Create(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create connection between Source and Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -108,7 +108,7 @@ func (d *sourceWarehouseConnectionResource) Read(ctx context.Context, req resour
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to read Source-Warehouse connection",
-				getError(err, body.Body),
+				getError(err, body),
 			)
 			return
 		}
@@ -158,7 +158,7 @@ func (r *sourceWarehouseConnectionResource) Delete(ctx context.Context, req reso
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to remove Source-Warehouse connection",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/tracking_plan_data_source.go
+++ b/internal/provider/tracking_plan_data_source.go
@@ -95,7 +95,7 @@ func (d *trackingPlanDataSource) Read(ctx context.Context, req datasource.ReadRe
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/tracking_plan_resource.go
+++ b/internal/provider/tracking_plan_resource.go
@@ -93,7 +93,7 @@ func (r *trackingPlanResource) Create(ctx context.Context, req resource.CreateRe
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -130,7 +130,7 @@ func (r *trackingPlanResource) Read(ctx context.Context, req resource.ReadReques
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -186,7 +186,7 @@ func (r *trackingPlanResource) Update(ctx context.Context, req resource.UpdateRe
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -195,7 +195,7 @@ func (r *trackingPlanResource) Update(ctx context.Context, req resource.UpdateRe
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -231,7 +231,7 @@ func (r *trackingPlanResource) Delete(ctx context.Context, req resource.DeleteRe
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Tracking Plan",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/tracking_plan_rules_data_source.go
+++ b/internal/provider/tracking_plan_rules_data_source.go
@@ -109,7 +109,7 @@ func (d *trackingPlanRulesDataSource) Read(ctx context.Context, req datasource.R
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to get Tracking Plan rules",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/tracking_plan_rules_resource.go
+++ b/internal/provider/tracking_plan_rules_resource.go
@@ -114,7 +114,7 @@ func (r *trackingPlanRulesResource) Create(ctx context.Context, req resource.Cre
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Tracking Plan rules",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -152,7 +152,7 @@ func (r *trackingPlanRulesResource) Read(ctx context.Context, req resource.ReadR
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to get Tracking Plan rules",
-				getError(err, body.Body),
+				getError(err, body),
 			)
 			return
 		}
@@ -191,7 +191,7 @@ func (r *trackingPlanRulesResource) Delete(ctx context.Context, req resource.Del
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Tracking Plan rules",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net/http"
 )
 
-func getError(err error, body io.ReadCloser) string {
-	parsedBody, readErr := io.ReadAll(body)
+func getError(err error, body *http.Response) string {
+	if body == nil {
+		return err.Error()
+	}
+	parsedBody, readErr := io.ReadAll(body.Body)
 	if readErr != nil {
 		return err.Error()
 	}

--- a/internal/provider/warehouse_data_source.go
+++ b/internal/provider/warehouse_data_source.go
@@ -79,7 +79,7 @@ func (d *warehouseDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/warehouse_metadata_data_source.go
+++ b/internal/provider/warehouse_metadata_data_source.go
@@ -122,7 +122,7 @@ func (d *warehouseMetadataDataSource) Read(ctx context.Context, req datasource.R
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Warehouse metadata",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/warehouse_resource.go
+++ b/internal/provider/warehouse_resource.go
@@ -224,7 +224,7 @@ func (r *warehouseResource) Create(ctx context.Context, req resource.CreateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -266,7 +266,7 @@ func (d *warehouseResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to read Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -323,7 +323,7 @@ func (r *warehouseResource) Update(ctx context.Context, req resource.UpdateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -343,7 +343,7 @@ func (r *warehouseResource) Update(ctx context.Context, req resource.UpdateReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to update Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}
@@ -381,7 +381,7 @@ func (r *warehouseResource) Delete(ctx context.Context, req resource.DeleteReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to delete Warehouse",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -61,7 +61,7 @@ func (d *workspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Workspace",
-			getError(err, body.Body),
+			getError(err, body),
 		)
 		return
 	}


### PR DESCRIPTION
Nil responses were leading to segfault. This fixes that issue by checking the pointer before access.