### PR TITLE
Run go install before generating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ deps:
 
 # Generates documentation
 generate:
+	@go install .
 	@go generate ./...
 .PHONY: generate
 


### PR DESCRIPTION
This removes the risk of documentation for an older version of the code being generated by accident (as what happened in #43)