### PR TITLE
Fix nil pointer access across repo

### DIFF
--- a/internal/provider/models/destination_metadata.go
+++ b/internal/provider/models/destination_metadata.go
@@ -102,11 +102,7 @@ type DestinationMetadataState struct {
 }
 
 func (d *DestinationMetadataState) getPartnerOwned(owned *bool) types.Bool {
-	var partnerOwned types.Bool
-
-	if owned != nil {
-		partnerOwned = types.BoolValue(*owned)
-	}
+	partnerOwned := types.BoolPointerValue(owned)
 
 	return partnerOwned
 }
@@ -114,17 +110,9 @@ func (d *DestinationMetadataState) getPartnerOwned(owned *bool) types.Bool {
 func (d *DestinationMetadataState) getSupportedPlatforms(platforms api.SupportedPlatforms) *SupportedPlatform {
 	var supportedPlatform SupportedPlatform
 
-	if platforms.Browser != nil {
-		supportedPlatform.Browser = types.BoolValue(*platforms.Browser)
-	}
-
-	if platforms.Server != nil {
-		supportedPlatform.Server = types.BoolValue(*platforms.Server)
-	}
-
-	if platforms.Mobile != nil {
-		supportedPlatform.Mobile = types.BoolValue(*platforms.Mobile)
-	}
+	supportedPlatform.Browser = types.BoolPointerValue(platforms.Browser)
+	supportedPlatform.Server = types.BoolPointerValue(platforms.Server)
+	supportedPlatform.Mobile = types.BoolPointerValue(platforms.Mobile)
 
 	return &supportedPlatform
 }
@@ -132,25 +120,11 @@ func (d *DestinationMetadataState) getSupportedPlatforms(platforms api.Supported
 func (d *DestinationMetadataState) getSupportedFeatures(features api.SupportedFeatures) *SupportedFeature {
 	var supportedFeature SupportedFeature
 
-	if features.CloudModeInstances != nil {
-		supportedFeature.CloudModeInstances = types.StringValue(*features.CloudModeInstances)
-	}
-
-	if features.DeviceModeInstances != nil {
-		supportedFeature.DeviceModeInstances = types.StringValue(*features.DeviceModeInstances)
-	}
-
-	if features.Replay != nil {
-		supportedFeature.Replay = types.BoolValue(*features.Replay)
-	}
-
-	if features.BrowserUnbundling != nil {
-		supportedFeature.BrowseUnbundling = types.BoolValue(*features.BrowserUnbundling)
-	}
-
-	if features.BrowserUnbundlingPublic != nil {
-		supportedFeature.BrowseUnbundlingPublic = types.BoolValue(*features.BrowserUnbundlingPublic)
-	}
+	supportedFeature.CloudModeInstances = types.StringPointerValue(features.CloudModeInstances)
+	supportedFeature.DeviceModeInstances = types.StringPointerValue(features.DeviceModeInstances)
+	supportedFeature.Replay = types.BoolPointerValue(features.Replay)
+	supportedFeature.BrowseUnbundling = types.BoolPointerValue(features.BrowserUnbundling)
+	supportedFeature.BrowseUnbundlingPublic = types.BoolPointerValue(features.BrowserUnbundlingPublic)
 
 	return &supportedFeature
 }
@@ -158,25 +132,11 @@ func (d *DestinationMetadataState) getSupportedFeatures(features api.SupportedFe
 func (d *DestinationMetadataState) getSupportedMethods(methods api.SupportedMethods) *SupportedMethod {
 	var supportedMethod SupportedMethod
 
-	if methods.Pageview != nil {
-		supportedMethod.PageView = types.BoolValue(*methods.Pageview)
-	}
-
-	if methods.Identify != nil {
-		supportedMethod.Identify = types.BoolValue(*methods.Identify)
-	}
-
-	if methods.Alias != nil {
-		supportedMethod.Alias = types.BoolValue(*methods.Alias)
-	}
-
-	if methods.Track != nil {
-		supportedMethod.Track = types.BoolValue(*methods.Track)
-	}
-
-	if methods.Group != nil {
-		supportedMethod.Group = types.BoolValue(*methods.Group)
-	}
+	supportedMethod.PageView = types.BoolPointerValue(methods.Pageview)
+	supportedMethod.Identify = types.BoolPointerValue(methods.Identify)
+	supportedMethod.Alias = types.BoolPointerValue(methods.Alias)
+	supportedMethod.Track = types.BoolPointerValue(methods.Track)
+	supportedMethod.Group = types.BoolPointerValue(methods.Group)
 
 	return &supportedMethod
 }
@@ -200,9 +160,7 @@ func (d *DestinationMetadataState) getComponents(components []api.DestinationMet
 			Code: types.StringValue(c.Code),
 		}
 
-		if c.Owner != nil {
-			componentToAdd.Owner = types.StringValue(*c.Owner)
-		}
+		componentToAdd.Owner = types.StringPointerValue(c.Owner)
 
 		componentsToAdd = append(componentsToAdd, componentToAdd)
 	}
@@ -235,10 +193,10 @@ func (d *DestinationMetadataState) getContacts(contacts []api.Contact) []Contact
 
 	for _, c := range contacts {
 		contactToAdd := Contact{
-			Name:      types.StringValue(*c.Name),
+			Name:      types.StringPointerValue(c.Name),
 			Email:     types.StringValue(c.Email),
-			Role:      types.StringValue(*c.Role),
-			IsPrimary: types.BoolValue(*c.IsPrimary),
+			Role:      types.StringPointerValue(c.Role),
+			IsPrimary: types.BoolPointerValue(c.IsPrimary),
 		}
 
 		contactsToAdd = append(contactsToAdd, contactToAdd)
@@ -315,9 +273,7 @@ func (d *DestinationMetadataState) getFields(fields []api.DestinationMetadataAct
 			AllowNull:   types.BoolValue(f.AllowNull),
 		}
 
-		if f.Placeholder != nil {
-			fieldToAdd.Placeholder = types.StringValue(*f.Placeholder)
-		}
+		fieldToAdd.Placeholder = types.StringPointerValue(f.Placeholder)
 
 		if f.DefaultValue != nil {
 			defaultValue, err := json.Marshal(f.DefaultValue)
@@ -345,11 +301,11 @@ func (d *DestinationMetadataState) getLogosDestinationMetadata(logos api.Logos) 
 	}
 
 	if logos.Mark.IsSet() {
-		logosToAdd.Mark = types.StringValue(*logos.Mark.Get())
+		logosToAdd.Mark = types.StringPointerValue(logos.Mark.Get())
 	}
 
 	if logos.Alt.IsSet() {
-		logosToAdd.Alt = types.StringValue(*logos.Alt.Get())
+		logosToAdd.Alt = types.StringPointerValue(logos.Alt.Get())
 	}
 
 	return &logosToAdd
@@ -365,13 +321,9 @@ func getOptions(options []api.IntegrationOptionBeta) ([]IntegrationOptionState, 
 			Required: types.BoolValue(opt.Required),
 		}
 
-		if opt.Description != nil {
-			integrationOption.Description = types.StringValue(*opt.Description)
-		}
+		integrationOption.Description = types.StringPointerValue(opt.Description)
 
-		if opt.Label != nil {
-			integrationOption.Label = types.StringValue(*opt.Label)
-		}
+		integrationOption.Label = types.StringPointerValue(opt.Label)
 
 		if opt.DefaultValue != nil {
 			defaultValue, err := json.Marshal(opt.DefaultValue)

--- a/internal/provider/models/source.go
+++ b/internal/provider/models/source.go
@@ -34,9 +34,7 @@ type SourceState struct {
 
 func (s *SourceState) Fill(source api.Source4) error {
 	s.ID = types.StringValue(source.Id)
-	if source.Name != nil {
-		s.Name = types.StringValue(*source.Name)
-	}
+	s.Name = types.StringPointerValue(source.Name)
 	s.Slug = types.StringValue(source.Slug)
 	s.Enabled = types.BoolValue(source.Enabled)
 	s.WorkspaceID = types.StringValue(source.WorkspaceId)

--- a/internal/provider/models/source_metadata.go
+++ b/internal/provider/models/source_metadata.go
@@ -65,11 +65,11 @@ func getLogos(logos api.Logos) *LogosState {
 	}
 
 	if logos.Mark.IsSet() {
-		logosToAdd.Mark = types.StringValue(*logos.Mark.Get())
+		logosToAdd.Mark = types.StringPointerValue(logos.Mark.Get())
 	}
 
 	if logos.Alt.IsSet() {
-		logosToAdd.Alt = types.StringValue(*logos.Alt.Get())
+		logosToAdd.Alt = types.StringPointerValue(logos.Alt.Get())
 	}
 
 	return &logosToAdd

--- a/internal/provider/models/tracking_plan.go
+++ b/internal/provider/models/tracking_plan.go
@@ -45,22 +45,12 @@ type TrackingPlanPlan struct {
 
 func (t *TrackingPlanState) Fill(trackingPlan api.TrackingPlan, rules *[]api.RuleV1) error {
 	t.ID = types.StringValue(trackingPlan.Id)
-	if trackingPlan.Name != nil {
-		t.Name = types.StringValue(*trackingPlan.Name)
-	}
-	if trackingPlan.Slug != nil {
-		t.Slug = types.StringValue(*trackingPlan.Slug)
-	}
-	if trackingPlan.Description != nil {
-		t.Description = types.StringValue(*trackingPlan.Description)
-	}
+	t.Name = types.StringPointerValue(trackingPlan.Name)
+	t.Slug = types.StringPointerValue(trackingPlan.Slug)
+	t.Description = types.StringPointerValue(trackingPlan.Description)
 	t.Type = types.StringValue(trackingPlan.Type)
-	if trackingPlan.UpdatedAt != nil {
-		t.UpdatedAt = types.StringValue(*trackingPlan.UpdatedAt)
-	}
-	if trackingPlan.CreatedAt != nil {
-		t.CreatedAt = types.StringValue(*trackingPlan.CreatedAt)
-	}
+	t.UpdatedAt = types.StringPointerValue(trackingPlan.UpdatedAt)
+	t.CreatedAt = types.StringPointerValue(trackingPlan.CreatedAt)
 
 	t.Rules = []RulesState{}
 	if rules != nil {
@@ -69,7 +59,7 @@ func (t *TrackingPlanState) Fill(trackingPlan api.TrackingPlan, rules *[]api.Rul
 
 			r.Type = types.StringValue(rule.Type)
 			if rule.Key != nil {
-				r.Key = types.StringValue(*rule.Key)
+				r.Key = types.StringPointerValue(rule.Key)
 			}
 
 			jsonSchema, err := json.Marshal(rule.JsonSchema)
@@ -89,22 +79,12 @@ func (t *TrackingPlanState) Fill(trackingPlan api.TrackingPlan, rules *[]api.Rul
 
 func (t *TrackingPlanDSState) Fill(trackingPlan api.TrackingPlan, rules *[]api.RuleV1) error {
 	t.ID = types.StringValue(trackingPlan.Id)
-	if trackingPlan.Name != nil {
-		t.Name = types.StringValue(*trackingPlan.Name)
-	}
-	if trackingPlan.Slug != nil {
-		t.Slug = types.StringValue(*trackingPlan.Slug)
-	}
-	if trackingPlan.Description != nil {
-		t.Description = types.StringValue(*trackingPlan.Description)
-	}
+	t.Name = types.StringPointerValue(trackingPlan.Name)
+	t.Slug = types.StringPointerValue(trackingPlan.Slug)
+	t.Description = types.StringPointerValue(trackingPlan.Description)
 	t.Type = types.StringValue(trackingPlan.Type)
-	if trackingPlan.UpdatedAt != nil {
-		t.UpdatedAt = types.StringValue(*trackingPlan.UpdatedAt)
-	}
-	if trackingPlan.CreatedAt != nil {
-		t.CreatedAt = types.StringValue(*trackingPlan.CreatedAt)
-	}
+	t.UpdatedAt = types.StringPointerValue(trackingPlan.UpdatedAt)
+	t.CreatedAt = types.StringPointerValue(trackingPlan.CreatedAt)
 
 	t.Rules = []RulesDSState{}
 	if rules != nil {
@@ -112,29 +92,16 @@ func (t *TrackingPlanDSState) Fill(trackingPlan api.TrackingPlan, rules *[]api.R
 			r := RulesDSState{}
 
 			r.Type = types.StringValue(rule.Type)
-			if rule.Key != nil {
-				r.Key = types.StringValue(*rule.Key)
-			}
-
+			r.Key = types.StringPointerValue(rule.Key)
 			jsonSchema, err := json.Marshal(rule.JsonSchema)
 			if err != nil {
 				return fmt.Errorf("could not marshal json: %w", err)
 			}
 			r.JSONSchema = jsontypes.NewNormalizedValue(string(jsonSchema))
-
 			r.Version = types.Float64Value(float64(rule.Version))
-
-			if rule.CreatedAt != nil {
-				r.CreatedAt = types.StringValue(*rule.CreatedAt)
-			}
-
-			if rule.UpdatedAt != nil {
-				r.UpdatedAt = types.StringValue(*rule.UpdatedAt)
-			}
-
-			if rule.DeprecatedAt != nil {
-				r.DeprecatedAt = types.StringValue(*rule.DeprecatedAt)
-			}
+			r.CreatedAt = types.StringPointerValue(rule.CreatedAt)
+			r.UpdatedAt = types.StringPointerValue(rule.UpdatedAt)
+			r.DeprecatedAt = types.StringPointerValue(rule.DeprecatedAt)
 
 			t.Rules = append(t.Rules, r)
 		}


### PR DESCRIPTION
Most were conditional, but using `.xPointerValue` is way cleaner and helps in case of missing conditional. 

Fixes #58, tested with `Google Analytics 4` destination.