### PR TITLE
Trim ifnd_ prefix when using function id directly in insert function instance

### DIFF
--- a/internal/provider/insert_function_instance_resource.go
+++ b/internal/provider/insert_function_instance_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/models"
 
@@ -94,7 +95,7 @@ func (r *insertFunctionInstanceResource) Create(ctx context.Context, req resourc
 	enabled := plan.Enabled.ValueBool()
 	out, body, err := r.client.FunctionsAPI.CreateInsertFunctionInstance(r.authContext).CreateInsertFunctionInstanceAlphaInput(api.CreateInsertFunctionInstanceAlphaInput{
 		Name:          plan.Name.ValueString(),
-		FunctionId:    plan.FunctionID.ValueString(),
+		FunctionId:    strings.TrimPrefix(plan.FunctionID.ValueString(), "ifnd_"),
 		IntegrationId: plan.IntegrationID.ValueString(),
 		Enabled:       &enabled,
 		Settings:      settings,
@@ -126,6 +127,9 @@ func (r *insertFunctionInstanceResource) Create(ctx context.Context, req resourc
 
 	// This is to satisfy terraform requirements that the returned fields must match the input ones because new settings can be generated in the response
 	state.Settings = plan.Settings
+
+	// This is to satisfy terraform requirements that the input fields must match the returned ones. The input FunctionID can be prefixed with "ifnd_" and the returned one is not.
+	state.FunctionID = plan.FunctionID
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, state)
@@ -172,6 +176,11 @@ func (r *insertFunctionInstanceResource) Read(ctx context.Context, req resource.
 
 	if !previousState.Settings.IsNull() && !previousState.Settings.IsUnknown() {
 		state.Settings = previousState.Settings
+	}
+
+	// This is to satisfy terraform requirements that the input fields must match the returned ones. The input FunctionID can be prefixed with "ifnd_" and the returned one is not.
+	if !previousState.Settings.IsNull() && !previousState.Settings.IsUnknown() {
+		state.FunctionID = previousState.FunctionID
 	}
 
 	diags = resp.State.Set(ctx, &state)
@@ -232,6 +241,9 @@ func (r *insertFunctionInstanceResource) Update(ctx context.Context, req resourc
 
 	// This is to satisfy terraform requirements that the returned fields must match the input ones because new settings can be generated in the response
 	state.Settings = plan.Settings
+
+	// This is to satisfy terraform requirements that the input fields must match the returned ones. The input FunctionID can be prefixed with "ifnd_" and the returned one is not.
+	state.FunctionID = plan.FunctionID
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/insert_function_instance_resource_test.go
+++ b/internal/provider/insert_function_instance_resource_test.go
@@ -11,55 +11,14 @@ import (
 func TestAccInsertFunctionInstanceResource(t *testing.T) {
 	t.Parallel()
 
-	updated := 0
-	fakeServer := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			w.Header().Set("content-type", "application/json")
+	t.Run("happy path", func(t *testing.T) {
+		updated := 0
+		fakeServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("content-type", "application/json")
 
-			payload := ""
-			if req.URL.Path == "/insert-function-instances" && req.Method == http.MethodPost {
-				payload = `
-					{
-						"data": {
-							"insertFunctionInstance": {
-								"id": "my-instance-id",
-								"name": "My instance name",
-								"integrationId": "my-integration-id",
-								"classId": "my-function-id",
-								"enabled": true,
-								"createdAt": "2023-11-01T18:38:01.349Z",
-								"updatedAt": "2023-11-01T18:41:29.318Z",
-								"settings": {
-									"apiKey": "abc123"
-								},
-								"encryptedSettings": {}
-							}
-						}
-					}
-				`
-			} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodPatch {
-				payload = `
-					{
-						"data": {
-							"insertFunctionInstance": {
-								"id": "my-instance-id",
-								"name": "My new instance name",
-								"integrationId": "my-integration-id",
-								"classId": "my-function-id",
-								"enabled": false,
-								"createdAt": "2023-11-01T18:38:01.349Z",
-								"updatedAt": "2023-11-01T18:41:29.318Z",
-								"settings": {
-									"apiKey": "cba321"
-								},
-								"encryptedSettings": {}
-							}
-						}
-					}
-				`
-				updated++
-			} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodGet {
-				if updated == 0 {
+				payload := ""
+				if req.URL.Path == "/insert-function-instances" && req.Method == http.MethodPost {
 					payload = `
 						{
 							"data": {
@@ -79,7 +38,7 @@ func TestAccInsertFunctionInstanceResource(t *testing.T) {
 							}
 						}
 					`
-				} else {
+				} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodPatch {
 					payload = `
 						{
 							"data": {
@@ -99,80 +58,255 @@ func TestAccInsertFunctionInstanceResource(t *testing.T) {
 							}
 						}
 					`
+					updated++
+				} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodGet {
+					if updated == 0 {
+						payload = `
+							{
+								"data": {
+									"insertFunctionInstance": {
+										"id": "my-instance-id",
+										"name": "My instance name",
+										"integrationId": "my-integration-id",
+										"classId": "my-function-id",
+										"enabled": true,
+										"createdAt": "2023-11-01T18:38:01.349Z",
+										"updatedAt": "2023-11-01T18:41:29.318Z",
+										"settings": {
+											"apiKey": "abc123"
+										},
+										"encryptedSettings": {}
+									}
+								}
+							}
+						`
+					} else {
+						payload = `
+							{
+								"data": {
+									"insertFunctionInstance": {
+										"id": "my-instance-id",
+										"name": "My new instance name",
+										"integrationId": "my-integration-id",
+										"classId": "my-function-id",
+										"enabled": false,
+										"createdAt": "2023-11-01T18:38:01.349Z",
+										"updatedAt": "2023-11-01T18:41:29.318Z",
+										"settings": {
+											"apiKey": "cba321"
+										},
+										"encryptedSettings": {}
+									}
+								}
+							}
+						`
+					}
 				}
+
+				_, _ = w.Write([]byte(payload))
+			}),
+		)
+		defer fakeServer.Close()
+
+		providerConfig := `
+			provider "segment" {
+				url   = "` + fakeServer.URL + `"
+				token = "abc123"
 			}
+		`
 
-			_, _ = w.Write([]byte(payload))
-		}),
-	)
-	defer fakeServer.Close()
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Create and Read testing
+				{
+					Config: providerConfig + `
+						resource "segment_insert_function_instance" "test" {
+							integration_id = "my-integration-id"
+							function_id = "my-function-id"
+							name = "My instance name"
+							enabled = true
+							settings = jsonencode({"apiKey": "abc123"})
+						}
+					`,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "id", "my-instance-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "integration_id", "my-integration-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "name", "My instance name"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "enabled", "true"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "function_id", "my-function-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "settings", "{\"apiKey\":\"abc123\"}"),
+					),
+				},
+				// ImportState testing
+				{
+					ResourceName: "segment_insert_function_instance.test",
+					Config: providerConfig + `
+						resource "segment_insert_function_instance" "test" {
+							integration_id = "my-integration-id"
+							function_id = "my-function-id"
+							name = "My instance name"
+							enabled = true
+							settings = jsonencode({"apiKey": "abc123"})
+						}
+					`,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				// Update and Read testing
+				{
+					Config: providerConfig + `
+						resource "segment_insert_function_instance" "test" {
+							integration_id = "my-integration-id"
+							function_id = "my-function-id"
+							name = "My new instance name"
+							enabled = false
+							settings = jsonencode({"apiKey": "cba321"})
+						}
+					`,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "id", "my-instance-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "integration_id", "my-integration-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "name", "My new instance name"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "enabled", "false"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "function_id", "my-function-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test", "settings", "{\"apiKey\":\"cba321\"}"),
+					),
+				},
+				// Delete testing automatically occurs in TestCase
+			},
+		})
+	})
 
-	providerConfig := `
+	t.Run("with prefix", func(t *testing.T) {
+		updated := 0
+		fakeServer := httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("content-type", "application/json")
+
+				payload := ""
+				if req.URL.Path == "/insert-function-instances" && req.Method == http.MethodPost {
+					payload = `
+					{
+						"data": {
+							"insertFunctionInstance": {
+								"id": "my-instance-id",
+								"name": "My instance name",
+								"integrationId": "my-integration-id",
+								"classId": "my-function-id",
+								"enabled": true,
+								"createdAt": "2023-11-01T18:38:01.349Z",
+								"updatedAt": "2023-11-01T18:41:29.318Z",
+								"settings": {
+									"apiKey": "abc123"
+								},
+								"encryptedSettings": {}
+							}
+						}
+					}
+				`
+				} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodPatch {
+					payload = `
+					{
+						"data": {
+							"insertFunctionInstance": {
+								"id": "my-instance-id",
+								"name": "My new instance name",
+								"integrationId": "my-integration-id",
+								"classId": "my-function-id",
+								"enabled": false,
+								"createdAt": "2023-11-01T18:38:01.349Z",
+								"updatedAt": "2023-11-01T18:41:29.318Z",
+								"settings": {
+									"apiKey": "cba321"
+								},
+								"encryptedSettings": {}
+							}
+						}
+					}
+				`
+					updated++
+				} else if req.URL.Path == "/insert-function-instances/my-instance-id" && req.Method == http.MethodGet {
+					if updated == 0 {
+						payload = `
+						{
+							"data": {
+								"insertFunctionInstance": {
+									"id": "my-instance-id",
+									"name": "My instance name",
+									"integrationId": "my-integration-id",
+									"classId": "my-function-id",
+									"enabled": true,
+									"createdAt": "2023-11-01T18:38:01.349Z",
+									"updatedAt": "2023-11-01T18:41:29.318Z",
+									"settings": {
+										"apiKey": "abc123"
+									},
+									"encryptedSettings": {}
+								}
+							}
+						}
+					`
+					} else {
+						payload = `
+						{
+							"data": {
+								"insertFunctionInstance": {
+									"id": "my-instance-id",
+									"name": "My new instance name",
+									"integrationId": "my-integration-id",
+									"classId": "my-function-id",
+									"enabled": false,
+									"createdAt": "2023-11-01T18:38:01.349Z",
+									"updatedAt": "2023-11-01T18:41:29.318Z",
+									"settings": {
+										"apiKey": "cba321"
+									},
+									"encryptedSettings": {}
+								}
+							}
+						}
+					`
+					}
+				}
+
+				_, _ = w.Write([]byte(payload))
+			}),
+		)
+		defer fakeServer.Close()
+
+		providerConfig := `
 		provider "segment" {
 			url   = "` + fakeServer.URL + `"
 			token = "abc123"
 		}
 	`
 
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: providerConfig + `
-					resource "segment_insert_function_instance" "test" {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				// Create and Read testing for 'ifnd_' prefixed fn
+				{
+					Config: providerConfig + `
+					resource "segment_insert_function_instance" "test_ifnd" {
 						integration_id = "my-integration-id"
-						function_id = "my-function-id"
+						function_id = "ifnd_my-function-id"
 						name = "My instance name"
 						enabled = true
 						settings = jsonencode({"apiKey": "abc123"})
 					}
 				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "id", "my-instance-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "integration_id", "my-integration-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "name", "My instance name"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "enabled", "true"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "function_id", "my-function-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "settings", "{\"apiKey\":\"abc123\"}"),
-				),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "id", "my-instance-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "integration_id", "my-integration-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "name", "My instance name"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "enabled", "true"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "function_id", "ifnd_my-function-id"),
+						resource.TestCheckResourceAttr("segment_insert_function_instance.test_ifnd", "settings", "{\"apiKey\":\"abc123\"}"),
+					),
+				},
 			},
-			// ImportState testing
-			{
-				ResourceName: "segment_insert_function_instance.test",
-				Config: providerConfig + `
-					resource "segment_insert_function_instance" "test" {
-						integration_id = "my-integration-id"
-						function_id = "my-function-id"
-						name = "My instance name"
-						enabled = true
-						settings = jsonencode({"apiKey": "abc123"})
-					}
-				`,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update and Read testing
-			{
-				Config: providerConfig + `
-					resource "segment_insert_function_instance" "test" {
-						integration_id = "my-integration-id"
-						function_id = "my-function-id"
-						name = "My new instance name"
-						enabled = false
-						settings = jsonencode({"apiKey": "cba321"})
-					}
-				`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "id", "my-instance-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "integration_id", "my-integration-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "name", "My new instance name"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "enabled", "false"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "function_id", "my-function-id"),
-					resource.TestCheckResourceAttr("segment_insert_function_instance.test", "settings", "{\"apiKey\":\"cba321\"}"),
-				),
-			},
-			// Delete testing automatically occurs in TestCase
-		},
+		})
 	})
+
 }

--- a/internal/provider/insert_function_instance_resource_test.go
+++ b/internal/provider/insert_function_instance_resource_test.go
@@ -12,6 +12,8 @@ func TestAccInsertFunctionInstanceResource(t *testing.T) {
 	t.Parallel()
 
 	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+
 		updated := 0
 		fakeServer := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -179,6 +181,8 @@ func TestAccInsertFunctionInstanceResource(t *testing.T) {
 	})
 
 	t.Run("with prefix", func(t *testing.T) {
+		t.Parallel()
+
 		updated := 0
 		fakeServer := httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
This makes the experience more seamless instead of needing to trim the id.

Tested with and without the prefix, and importing.