### PR TITLE
Fix nil pointer reference in profiles warehouse

### DIFF
--- a/internal/provider/profiles_warehouse_resource.go
+++ b/internal/provider/profiles_warehouse_resource.go
@@ -178,7 +178,7 @@ func (r *profilesWarehouseResource) Read(ctx context.Context, req resource.ReadR
 	if warehouse == nil {
 		resp.Diagnostics.AddError(
 			"Unable to find Profile Warehouse",
-			err.Error(),
+			fmt.Sprintf("Profile Warehouse with id '%s' and space id '%s' not found", previousState.ID.ValueString(), previousState.SpaceID.ValueString()),
 		)
 
 		return


### PR DESCRIPTION
Avoids segfault when importing the resource with invalid IDs.