### PR TITLE
Fix reverse_etl_model import type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.2 (Aug 1, 2024)
+Fixes a bug where imported `segment_reverse_etl_model` resources could have invalid configuration parameters.
+
 ## 1.0.1 (April 18, 2024)
 Fixes a bug where the `segment_profiles_warehouse` resource was dereferencing a nil pointer upon invalid import.
 

--- a/internal/provider/models/reverse_etl_model.go
+++ b/internal/provider/models/reverse_etl_model.go
@@ -32,6 +32,10 @@ func (r *ReverseETLModelState) Fill(model api.ReverseEtlModel) error {
 		return err
 	}
 	r.ScheduleConfig = scheduleConfig
+	if r.ScheduleConfig.IsNull() {
+		empty := "{}"
+		r.ScheduleConfig = jsontypes.NewNormalizedPointerValue(&empty)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Existing reverse etl models could have `undefined` schedule config, so this coerces those into a value that is valid for the provider.