### PR TITLE
Allow clearing user group users

### DIFF
--- a/internal/provider/user_group_resource.go
+++ b/internal/provider/user_group_resource.go
@@ -352,21 +352,19 @@ func (r *userGroupResource) Update(ctx context.Context, req resource.UpdateReque
 	for _, member := range plan.Members {
 		members = append(members, member.ValueString())
 	}
-	if len(members) > 0 {
-		_, body, err = r.client.IAMGroupsAPI.ReplaceUsersInUserGroup(r.authContext, config.ID.ValueString()).ReplaceUsersInUserGroupV1Input(api.ReplaceUsersInUserGroupV1Input{
-			Emails: members,
-		}).Execute()
-		if body != nil {
-			defer body.Body.Close()
-		}
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Unable to add users/invites to User Group",
-				getError(err, body),
-			)
+	_, body, err = r.client.IAMGroupsAPI.ReplaceUsersInUserGroup(r.authContext, config.ID.ValueString()).ReplaceUsersInUserGroupV1Input(api.ReplaceUsersInUserGroupV1Input{
+		Emails: members,
+	}).Execute()
+	if body != nil {
+		defer body.Body.Close()
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to add users/invites to User Group",
+			getError(err, body),
+		)
 
-			return
-		}
+		return
 	}
 
 	getOut, body, err := r.client.IAMGroupsAPI.GetUserGroup(r.authContext, config.ID.ValueString()).Execute()


### PR DESCRIPTION
We had an accidental non-zero length check on group users before calling `replaceUsersInUserGroup`, which made it impossible to clear all users from the group. This PR removes that check. Fixes #135.

Tested adding and removing users from the group and ensuring output and resulting state is correct.