### PR TITLE
Stop connecting sources and warehouses by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0 (August 20, 2024)
+Stops connecting newly created sources and warehouses by default.
+
 ## 1.0.5 (August 12, 2024)
 Fixes a bug where user groups could not be cleared.
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20231114153454-3be55fde5c99
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240909200753-311bb8d791a2
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
-	github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56
+	github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50
 	gotest.tools/gotestsum v1.12.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/segmentio/public-api-sdk-go v0.0.0-20240820173358-a52384e5ccc7 h1:04d
 github.com/segmentio/public-api-sdk-go v0.0.0-20240820173358-a52384e5ccc7/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a h1:vSCltBxaOD5NRP3zGh/Xha3evkt0ZeXdAc6fTDTuwzg=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da h1:SiFK2+vk+r2zEfUUZm2FbfY6F050L5zPzKsCGlvdUg4=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a h1:vSC
 github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da h1:SiFK2+vk+r2zEfUUZm2FbfY6F050L5zPzKsCGlvdUg4=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56 h1:IKxTy9Mw02je+m8AhpnYaKqrrjzBzHRn+Y99C4kGsEo=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,10 @@ github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56 h1:IKx
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50 h1:RsFkUN2lGzupgzXLsWdDdvsPp1oj6kwHLgucV77MPCk=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240906235131-c22dd0e0d0b9 h1:g8gpxgqCPsFvOKhu55fPXl6H3wNm0CdbOH8cNri/1Fs=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240906235131-c22dd0e0d0b9/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240909200753-311bb8d791a2 h1:vlKTelJ32DPBuiiSx2PJaxN9jJd3OFK2avHU/XR/qB8=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240909200753-311bb8d791a2/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -185,10 +185,10 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/segmentio/public-api-sdk-go v0.0.0-20231114153454-3be55fde5c99 h1:55dfJRsEeZLLFln+0gQ1pNZvalFMyeMV9nTPQwShkok=
-github.com/segmentio/public-api-sdk-go v0.0.0-20231114153454-3be55fde5c99/go.mod h1:1mLoKkR7t90unwNx7qx9PicO3AX5NflFD7ny3TvLExU=
-github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028 h1:mY+y1F+uVH9D2rGZDzrJf8fNaoGAWXMKNz857VYpc3k=
-github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240820173358-a52384e5ccc7 h1:04d9X+Bw1RY+lmbs0DajdA61xSQOZCAIUJuZfcFpz0g=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240820173358-a52384e5ccc7/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a h1:vSCltBxaOD5NRP3zGh/Xha3evkt0ZeXdAc6fTDTuwzg=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240820210528-faf5e1da4b4a/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,8 @@ github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da h1:SiF
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905000934-07e8214ff9da/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56 h1:IKxTy9Mw02je+m8AhpnYaKqrrjzBzHRn+Y99C4kGsEo=
 github.com/segmentio/public-api-sdk-go v0.0.0-20240905231636-2922a096fe56/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50 h1:RsFkUN2lGzupgzXLsWdDdvsPp1oj6kwHLgucV77MPCk=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240906231017-4e91c4889f50/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3V
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/segmentio/public-api-sdk-go v0.0.0-20231114153454-3be55fde5c99 h1:55dfJRsEeZLLFln+0gQ1pNZvalFMyeMV9nTPQwShkok=
 github.com/segmentio/public-api-sdk-go v0.0.0-20231114153454-3be55fde5c99/go.mod h1:1mLoKkR7t90unwNx7qx9PicO3AX5NflFD7ny3TvLExU=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028 h1:mY+y1F+uVH9D2rGZDzrJf8fNaoGAWXMKNz857VYpc3k=
+github.com/segmentio/public-api-sdk-go v0.0.0-20240819211447-e2f7f9318028/go.mod h1:yKkoPfcOkkYjiZQj4lRWxji0Qwc6ncNEf7wCfywochY=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -200,7 +200,7 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 	var state models.FunctionState
 
 	function := response.Data.GetFunction()
-	state.Fill(api.FunctionV1(function))
+	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -200,7 +200,7 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 	var state models.FunctionState
 
 	function := response.Data.GetFunction()
-	state.Fill(function)
+	state.Fill(api.FunctionV1(function))
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -159,7 +159,7 @@ func (r *functionResource) Create(ctx context.Context, req resource.CreateReques
 	resp.State.SetAttribute(ctx, path.Root("id"), function.Id)
 
 	var state models.FunctionState
-	state.Fill(api.FunctionV1(function))
+	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {
@@ -256,7 +256,7 @@ func (r *functionResource) Update(ctx context.Context, req resource.UpdateReques
 
 	function := out.Data.GetFunction()
 
-	state.Fill(api.FunctionV1(function))
+	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -159,7 +159,7 @@ func (r *functionResource) Create(ctx context.Context, req resource.CreateReques
 	resp.State.SetAttribute(ctx, path.Root("id"), function.Id)
 
 	var state models.FunctionState
-	state.Fill(api.Function(function))
+	state.Fill(api.FunctionV1(function))
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {
@@ -256,7 +256,7 @@ func (r *functionResource) Update(ctx context.Context, req resource.UpdateReques
 
 	function := out.Data.GetFunction()
 
-	state.Fill(api.Function(function))
+	state.Fill(api.FunctionV1(function))
 
 	// Destination functions append workspace name to display name causing inconsistency
 	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {

--- a/internal/provider/models/function.go
+++ b/internal/provider/models/function.go
@@ -41,7 +41,7 @@ type FunctionPlan struct {
 	Settings          types.Set    `tfsdk:"settings"`
 }
 
-func (f *FunctionState) Fill(function api.Function) {
+func (f *FunctionState) Fill(function api.FunctionV1) {
 	f.ID = types.StringPointerValue(function.Id)
 	f.Code = types.StringPointerValue(function.Code)
 	f.DisplayName = types.StringPointerValue(function.DisplayName)

--- a/internal/provider/models/reverse_etl_model.go
+++ b/internal/provider/models/reverse_etl_model.go
@@ -1,9 +1,6 @@
 package models
 
 import (
-	"encoding/json"
-	"errors"
-
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/segmentio/public-api-sdk-go/api"
@@ -48,8 +45,7 @@ func GetScheduleConfig(scheduleConfig api.NullableScheduleConfig) (jsontypes.Nor
 		return jsontypes.NewNormalizedNull(), nil
 	}
 
-	jsonScheduleConfigString, err := json.Marshal(scheduleConfig)
-	return jsontypes.NewNormalizedNull(), errors.New(string(jsonScheduleConfigString))
+	jsonScheduleConfigString, err := scheduleConfig.Get().MarshalJSON()
 	if err != nil {
 		return jsontypes.NewNormalizedNull(), err
 	}

--- a/internal/provider/models/reverse_etl_model.go
+++ b/internal/provider/models/reverse_etl_model.go
@@ -27,7 +27,7 @@ func (r *ReverseETLModelState) Fill(model api.ReverseEtlModel) error {
 	r.ScheduleStrategy = types.StringValue(model.ScheduleStrategy)
 	r.Query = types.StringValue(model.Query)
 	r.QueryIdentifierColumn = types.StringValue(model.QueryIdentifierColumn)
-	scheduleConfig, err := GetSettings(model.ScheduleConfig)
+	scheduleConfig, err := GetScheduleConfig(model.ScheduleConfig)
 	if err != nil {
 		return err
 	}
@@ -38,4 +38,21 @@ func (r *ReverseETLModelState) Fill(model api.ReverseEtlModel) error {
 	}
 
 	return nil
+}
+
+func GetScheduleConfig(scheduleConfig api.NullableScheduleConfig) (jsontypes.Normalized, error) {
+	if !scheduleConfig.IsSet() {
+		return jsontypes.NewNormalizedNull(), nil
+	}
+
+	jsonScheduleConfigString, err := scheduleConfig.Get().MarshalJSON()
+	if err != nil {
+		return jsontypes.NewNormalizedNull(), err
+	}
+
+	if jsonScheduleConfigString == nil {
+		return jsontypes.NewNormalizedValue("{}"), nil
+	}
+
+	return jsontypes.NewNormalizedValue(string(jsonScheduleConfigString)), nil
 }

--- a/internal/provider/models/reverse_etl_model.go
+++ b/internal/provider/models/reverse_etl_model.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"encoding/json"
+	"errors"
+
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/segmentio/public-api-sdk-go/api"
@@ -45,7 +48,8 @@ func GetScheduleConfig(scheduleConfig api.NullableScheduleConfig) (jsontypes.Nor
 		return jsontypes.NewNormalizedNull(), nil
 	}
 
-	jsonScheduleConfigString, err := scheduleConfig.Get().MarshalJSON()
+	jsonScheduleConfigString, err := json.Marshal(scheduleConfig)
+	return jsontypes.NewNormalizedNull(), errors.New(string(jsonScheduleConfigString))
 	if err != nil {
 		return jsontypes.NewNormalizedNull(), err
 	}

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -276,11 +276,14 @@ func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	disconnectAllWarehouses := true
+
 	out, body, err := r.client.SourcesAPI.CreateSource(r.authContext).CreateSourceV1Input(api.CreateSourceV1Input{
-		Slug:       plan.Slug.ValueString(),
-		Enabled:    plan.Enabled.ValueBool(),
-		MetadataId: metadataID,
-		Settings:   settings,
+		Slug:                    plan.Slug.ValueString(),
+		Enabled:                 plan.Enabled.ValueBool(),
+		MetadataId:              metadataID,
+		Settings:                settings,
+		DisconnectAllWarehouses: &disconnectAllWarehouses,
 	}).Execute()
 	if body != nil {
 		defer body.Body.Close()

--- a/internal/provider/warehouse_resource.go
+++ b/internal/provider/warehouse_resource.go
@@ -219,11 +219,14 @@ func (r *warehouseResource) Create(ctx context.Context, req resource.CreateReque
 		name = nil
 	}
 
+	disconnectAllSources := true
+
 	out, body, err := r.client.WarehousesAPI.CreateWarehouse(r.authContext).CreateWarehouseV1Input(api.CreateWarehouseV1Input{
-		Enabled:    plan.Enabled.ValueBoolPointer(),
-		MetadataId: metadataID,
-		Settings:   settings,
-		Name:       name,
+		Enabled:              plan.Enabled.ValueBoolPointer(),
+		MetadataId:           metadataID,
+		Settings:             settings,
+		Name:                 name,
+		DisconnectAllSources: &disconnectAllSources,
 	}).Execute()
 	if body != nil {
 		defer body.Body.Close()


### PR DESCRIPTION
Currently, a newly created source is automatically connected to all existing warehouses and vice versa. This PR changes the behavior to switch to default disconnect. Instead use `segment_source_warehouse_connection` resource to configure connections.

```
resource "segment_source" "my_source" {
  slug = "my-source"
  metadata = {
    id = "XE0vf1bTDh"
  }
  settings = jsonencode({})
  enabled = true
}

resource "segment_warehouse" "my_warehouse" {
  metadata = {
    id = "aea3c55dsz"
  }
  name    = "test"
  enabled = true
  settings = jsonencode({...})
}

resource "segment_source_warehouse_connection" "connection" {
  source_id    = segment_source.my_source.id
  warehouse_id = segment_warehouse.my_warehouse.id
}
```