### PR TITLE
Overwrite RETL model resource schedule values even if null

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           version: latest
 
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - forcetypeassert
     - godot
     - gofmt
-    - gomnd
     - gosimple
     - govet
     - ineffassign

--- a/internal/provider/reverse_etl_model_resource.go
+++ b/internal/provider/reverse_etl_model_resource.go
@@ -187,10 +187,10 @@ func (r *reverseETLModelResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	// Since we deprecated these values, we just need to set them to the plan values so there are no errors
-	if !previousState.ScheduleConfig.IsNull() && !previousState.ScheduleConfig.IsUnknown() {
+	if !previousState.ScheduleConfig.IsUnknown() {
 		resp.State.SetAttribute(ctx, path.Root("schedule_config"), previousState.ScheduleConfig)
 	}
-	if !previousState.ScheduleStrategy.IsNull() && !previousState.ScheduleStrategy.IsUnknown() {
+	if !previousState.ScheduleStrategy.IsUnknown() {
 		resp.State.SetAttribute(ctx, path.Root("schedule_strategy"), previousState.ScheduleStrategy)
 	}
 }

--- a/internal/provider/reverse_etl_model_resource_test.go
+++ b/internal/provider/reverse_etl_model_resource_test.go
@@ -28,9 +28,7 @@ func TestAccReverseETLModelResource(t *testing.T) {
 								"description": "My reverse etl model description",
 								"enabled": true,
 								"query": "SELECT hi FROM greetings",
-								"queryIdentifierColumn": "hi",
-								"scheduleStrategy": "SPECIFIC_DAYS",
-								"scheduleConfig": {"days":[0,1,2,3],"hours":[0,1,3,2],"timezone":"America/Los_Angeles"}
+								"queryIdentifierColumn": "hi"
 							}
 						}
 					}
@@ -46,9 +44,7 @@ func TestAccReverseETLModelResource(t *testing.T) {
 								"description": "My new reverse etl model description",
 								"enabled": false,
 								"query": "SELECT hello FROM greetings",
-								"queryIdentifierColumn": "hello",
-								"scheduleStrategy": "SPECIFIC_DAYS",
-								"scheduleConfig": {"days":[0,1,2,3,4],"hours":[0,1,5],"timezone":"America/Los_Angeles"}
+								"queryIdentifierColumn": "hello"
 							}
 						}
 					}
@@ -66,9 +62,7 @@ func TestAccReverseETLModelResource(t *testing.T) {
 									"description": "My reverse etl model description",
 									"enabled": true,
 									"query": "SELECT hi FROM greetings",
-									"queryIdentifierColumn": "hi",
-									"scheduleStrategy": "SPECIFIC_DAYS",
-									"scheduleConfig": {"days":[0,1,2,3],"hours":[0,1,3,2],"timezone":"America/Los_Angeles"}
+									"queryIdentifierColumn": "hi"
 								}
 							}
 						}
@@ -84,9 +78,7 @@ func TestAccReverseETLModelResource(t *testing.T) {
 									"description": "My new reverse etl model description",
 									"enabled": false,
 									"query": "SELECT hello FROM greetings",
-									"queryIdentifierColumn": "hello",
-									"scheduleStrategy": "SPECIFIC_DAYS",
-									"scheduleConfig": {"days":[0,1,2,3,4],"hours":[0,1,5],"timezone":"America/Los_Angeles"}
+									"queryIdentifierColumn": "hello"
 								}
 							}
 						}
@@ -117,14 +109,8 @@ func TestAccReverseETLModelResource(t *testing.T) {
 						name                    = "My reverse etl model name"
 						enabled                 = true
 						description             = "My reverse etl model description"
-						schedule_strategy       = "SPECIFIC_DAYS"
 						query                   = "SELECT hi FROM greetings"
 						query_identifier_column = "hi"
-						schedule_config         = jsonencode({
-							"days": [0, 1, 2, 3],
-							"hours": [0, 1, 3, 2],
-							"timezone": "America/Los_Angeles"
-						})
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -133,10 +119,8 @@ func TestAccReverseETLModelResource(t *testing.T) {
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "name", "My reverse etl model name"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "description", "My reverse etl model description"),
-					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "schedule_strategy", "SPECIFIC_DAYS"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "query", "SELECT hi FROM greetings"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "query_identifier_column", "hi"),
-					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "schedule_config", "{\"days\":[0,1,2,3],\"hours\":[0,1,3,2],\"timezone\":\"America/Los_Angeles\"}"),
 				),
 			},
 			// ImportState testing
@@ -148,14 +132,8 @@ func TestAccReverseETLModelResource(t *testing.T) {
 						name                    = "My reverse etl model name"
 						enabled                 = true
 						description             = "My reverse etl model description"
-						schedule_strategy       = "SPECIFIC_DAYS"
 						query                   = "SELECT hi FROM greetings"
 						query_identifier_column = "hi"
-						schedule_config         = jsonencode({
-							"days": [0, 1, 2, 3],
-							"hours": [0, 1, 3, 2],
-							"timezone": "America/Los_Angeles"
-						})
 					}
 				`,
 				ImportState:       true,
@@ -169,14 +147,8 @@ func TestAccReverseETLModelResource(t *testing.T) {
 						name                    = "My new reverse etl model name"
 						enabled                 = false
 						description             = "My new reverse etl model description"
-						schedule_strategy       = "SPECIFIC_DAYS"
 						query                   = "SELECT hello FROM greetings"
 						query_identifier_column = "hello"
-						schedule_config         = jsonencode({
-							"days": [0, 1, 2, 3, 4],
-							"hours": [0, 1, 5],
-							"timezone": "America/Los_Angeles"
-						})
 					}
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -185,10 +157,8 @@ func TestAccReverseETLModelResource(t *testing.T) {
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "name", "My new reverse etl model name"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "enabled", "false"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "description", "My new reverse etl model description"),
-					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "schedule_strategy", "SPECIFIC_DAYS"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "query", "SELECT hello FROM greetings"),
 					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "query_identifier_column", "hello"),
-					resource.TestCheckResourceAttr("segment_reverse_etl_model.test", "schedule_config", "{\"days\":[0,1,2,3,4],\"hours\":[0,1,5],\"timezone\":\"America/Los_Angeles\"}"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
Since these fields are deprecated and no longer passed to Public API, we are overwriting them with whatever the previous value was to prevent recurring diffs. This has no impact on actual applies since this field is ignored, but it was confusing to see the diff continually pop up.

This prevents changes like this from recurring:
```
Terraform will perform the following actions:

  # segment_reverse_etl_model.example will be updated in-place
  ~ resource "segment_reverse_etl_model" "example" {
        id                      = "abc123"
        name                    = "name"
      - schedule_config         = jsonencode({})
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Addresses #160 