### PR TITLE
adds retryablehttp client in place of standard

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -128,6 +129,9 @@ func (p *segmentProvider) Configure(ctx context.Context, req provider.ConfigureR
 			URL: url,
 		},
 	}
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 10
+	configuration.HTTPClient = retryClient.StandardClient()
 
 	client := api.NewAPIClient(configuration)
 


### PR DESCRIPTION
> retryablehttp performs automatic retries under certain conditions

https://pkg.go.dev/github.com/hashicorp/go-retryablehttp

~~It's not clear to me if~~ it will handle 429 by default, ~~but~~ it says this about the `DefaultBackoff` function:
> DefaultBackoff provides a default callback for Client.Backoff which will perform exponential backoff based on the attempt number and limited by the provided minimum and maximum durations.
>
> It also tries to parse Retry-After response header when a http.StatusTooManyRequests (HTTP Code 429) is found in the resp parameter. Hence it will return the number of seconds the server states it may be ready to process more requests from this client.

Tested locally by running `public-api` pointed to staging, but with the rate limit down to just 1 rpm.

Without the plugin (v1.2.2):
<img width="491" alt="Screenshot 2025-01-22 at 3 43 29 PM" src="https://github.com/user-attachments/assets/fee77acd-e2cf-4d03-856b-df99994bf5e1" />

With the retryable plugin:
<img width="591" alt="Screenshot 2025-01-22 at 3 43 42 PM" src="https://github.com/user-attachments/assets/df22879a-d1c1-4a5a-a7cb-c58347f0ad74" />




