### PR TITLE
Handle 404s during reads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused

--- a/internal/provider/destination_filter_resource.go
+++ b/internal/provider/destination_filter_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -201,7 +202,7 @@ func (r *destinationFilterResource) Read(ctx context.Context, req resource.ReadR
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/destination_filter_resource.go
+++ b/internal/provider/destination_filter_resource.go
@@ -201,6 +201,12 @@ func (r *destinationFilterResource) Read(ctx context.Context, req resource.ReadR
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Destination Filter (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -587,7 +588,7 @@ func (r *destinationResource) Read(ctx context.Context, req resource.ReadRequest
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -587,6 +587,12 @@ func (r *destinationResource) Read(ctx context.Context, req resource.ReadRequest
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Destination (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/destination_subscription_resource.go
+++ b/internal/provider/destination_subscription_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
@@ -228,7 +229,7 @@ func (r *destinationSubscriptionResource) Read(ctx context.Context, req resource
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/destination_subscription_resource.go
+++ b/internal/provider/destination_subscription_resource.go
@@ -228,6 +228,12 @@ func (r *destinationSubscriptionResource) Read(ctx context.Context, req resource
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Destination subscription (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -189,6 +189,12 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Function (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
@@ -189,7 +190,7 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/insert_function_instance_resource.go
+++ b/internal/provider/insert_function_instance_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
@@ -159,7 +160,7 @@ func (r *insertFunctionInstanceResource) Read(ctx context.Context, req resource.
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/insert_function_instance_resource.go
+++ b/internal/provider/insert_function_instance_resource.go
@@ -159,6 +159,12 @@ func (r *insertFunctionInstanceResource) Read(ctx context.Context, req resource.
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Insert Function instance (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/label_resource.go
+++ b/internal/provider/label_resource.go
@@ -163,10 +163,7 @@ func (r *labelResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	if label == nil {
-		resp.Diagnostics.AddError(
-			"Unable to find Label",
-			fmt.Sprintf("Unable to find Label with key: %q and value: %q", state.Key, state.Value),
-		)
+		resp.State.RemoveResource(ctx)
 
 		return
 	}

--- a/internal/provider/profiles_warehouse_resource.go
+++ b/internal/provider/profiles_warehouse_resource.go
@@ -167,6 +167,8 @@ func (r *profilesWarehouseResource) Read(ctx context.Context, req resource.ReadR
 
 	warehouse, err := findProfileWarehouse(r.authContext, r.client, previousState.ID.ValueString(), previousState.SpaceID.ValueString())
 	if err != nil {
+		resp.State.RemoveResource(ctx)
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Profiles Warehouse (ID: %s)", previousState.ID.ValueString()),
 			err.Error(),
@@ -176,10 +178,7 @@ func (r *profilesWarehouseResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	if warehouse == nil {
-		resp.Diagnostics.AddError(
-			"Unable to find Profile Warehouse",
-			fmt.Sprintf("Profile Warehouse with id '%s' and space id '%s' not found", previousState.ID.ValueString(), previousState.SpaceID.ValueString()),
-		)
+		resp.State.RemoveResource(ctx)
 
 		return
 	}

--- a/internal/provider/reverse_etl_model_resource.go
+++ b/internal/provider/reverse_etl_model_resource.go
@@ -160,6 +160,12 @@ func (r *reverseETLModelResource) Read(ctx context.Context, req resource.ReadReq
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Reverse ETL model (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/reverse_etl_model_resource.go
+++ b/internal/provider/reverse_etl_model_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
 	"github.com/segmentio/terraform-provider-segment/internal/provider/models"
@@ -160,7 +161,7 @@ func (r *reverseETLModelResource) Read(ctx context.Context, req resource.ReadReq
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -387,7 +388,7 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -387,6 +387,12 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Source (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/source_tracking_plan_connection_resource.go
+++ b/internal/provider/source_tracking_plan_connection_resource.go
@@ -255,6 +255,12 @@ func (r *sourceTrackingPlanConnectionResource) Read(ctx context.Context, req res
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Source (ID: %s)", previousState.SourceID.ValueString()),
 			getError(err, body),

--- a/internal/provider/source_tracking_plan_connection_resource.go
+++ b/internal/provider/source_tracking_plan_connection_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/avast/retry-go/v4"
@@ -255,7 +256,7 @@ func (r *sourceTrackingPlanConnectionResource) Read(ctx context.Context, req res
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/source_warehouse_connection_resource.go
+++ b/internal/provider/source_warehouse_connection_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -126,7 +127,7 @@ func (r *sourceWarehouseConnectionResource) Read(ctx context.Context, req resour
 			defer body.Body.Close()
 		}
 		if err != nil {
-			if body.StatusCode == 404 {
+			if body.StatusCode == http.StatusNotFound {
 				resp.State.RemoveResource(ctx)
 
 				return

--- a/internal/provider/source_warehouse_connection_resource.go
+++ b/internal/provider/source_warehouse_connection_resource.go
@@ -126,6 +126,12 @@ func (r *sourceWarehouseConnectionResource) Read(ctx context.Context, req resour
 			defer body.Body.Close()
 		}
 		if err != nil {
+			if body.StatusCode == 404 {
+				resp.State.RemoveResource(ctx)
+
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"Unable to read Source-Warehouse connection",
 				getError(err, body),

--- a/internal/provider/tracking_plan_resource.go
+++ b/internal/provider/tracking_plan_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
 	"github.com/segmentio/terraform-provider-segment/internal/provider/models"
@@ -227,7 +228,7 @@ func (r *trackingPlanResource) Read(ctx context.Context, req resource.ReadReques
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/tracking_plan_resource.go
+++ b/internal/provider/tracking_plan_resource.go
@@ -227,6 +227,12 @@ func (r *trackingPlanResource) Read(ctx context.Context, req resource.ReadReques
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Tracking Plan (ID: %s)", config.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/transformation_resource.go
+++ b/internal/provider/transformation_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
 	"github.com/segmentio/terraform-provider-segment/internal/provider/models"
@@ -206,7 +207,7 @@ func (r *transformationResource) Read(ctx context.Context, req resource.ReadRequ
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 || body.StatusCode == 403 {
+		if body.StatusCode == http.StatusNotFound || body.StatusCode == http.StatusForbidden {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/transformation_resource.go
+++ b/internal/provider/transformation_resource.go
@@ -206,6 +206,12 @@ func (r *transformationResource) Read(ctx context.Context, req resource.ReadRequ
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 || body.StatusCode == 403 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Transformation (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/user_group_resource.go
+++ b/internal/provider/user_group_resource.go
@@ -238,6 +238,12 @@ func (r *userGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read User Group (ID: %s)", config.ID.ValueString()),
 			getError(err, body),

--- a/internal/provider/user_group_resource.go
+++ b/internal/provider/user_group_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
@@ -238,7 +239,7 @@ func (r *userGroupResource) Read(ctx context.Context, req resource.ReadRequest, 
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -259,6 +259,12 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			defer body.Body.Close()
 		}
 		if err != nil {
+			if body.StatusCode == 404 {
+				resp.State.RemoveResource(ctx)
+
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				fmt.Sprintf("Unable to read user (ID: %s)", state.ID.ValueString()),
 				getError(err, body),

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -259,7 +260,7 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 			defer body.Body.Close()
 		}
 		if err != nil {
-			if body.StatusCode == 404 {
+			if body.StatusCode == http.StatusNotFound {
 				resp.State.RemoveResource(ctx)
 
 				return

--- a/internal/provider/warehouse_resource.go
+++ b/internal/provider/warehouse_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/segmentio/terraform-provider-segment/internal/provider/docs"
 	"github.com/segmentio/terraform-provider-segment/internal/provider/models"
@@ -288,7 +289,7 @@ func (r *warehouseResource) Read(ctx context.Context, req resource.ReadRequest, 
 		defer body.Body.Close()
 	}
 	if err != nil {
-		if body.StatusCode == 404 {
+		if body.StatusCode == http.StatusNotFound {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/warehouse_resource.go
+++ b/internal/provider/warehouse_resource.go
@@ -288,6 +288,12 @@ func (r *warehouseResource) Read(ctx context.Context, req resource.ReadRequest, 
 		defer body.Body.Close()
 	}
 	if err != nil {
+		if body.StatusCode == 404 {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Unable to read Warehouse (ID: %s)", previousState.ID.ValueString()),
 			getError(err, body),


### PR DESCRIPTION
Gracefully handles missing resources during reads. Removing the resource from the state causes it to trigger a create during the apply like so:
![Screenshot 2025-04-04 at 5 36 39 PM](https://github.com/user-attachments/assets/8af09eb8-0b0c-4b1b-814f-7a2993913499)

Tested on each affected resource by creating one, deleting through the API, then retriggering a `terraform apply` to ensure it is handled correctly.

Addresses #179