### PR TITLE
[FUNK-1866] - Source insert function handling with terraform

### DIFF
--- a/internal/provider/function_resource.go
+++ b/internal/provider/function_resource.go
@@ -163,7 +163,7 @@ func (r *functionResource) Create(ctx context.Context, req resource.CreateReques
 	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
-	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {
+	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" || state.ResourceType.ValueString() == "INSERT_SOURCE"{
 		state.DisplayName = plan.DisplayName
 	}
 
@@ -210,7 +210,7 @@ func (r *functionResource) Read(ctx context.Context, req resource.ReadRequest, r
 	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
-	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {
+	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" || state.ResourceType.ValueString() == "INSERT_SOURCE"{
 		state.DisplayName = previousState.DisplayName
 	}
 
@@ -266,7 +266,7 @@ func (r *functionResource) Update(ctx context.Context, req resource.UpdateReques
 	state.Fill(function)
 
 	// Destination functions append workspace name to display name causing inconsistency
-	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" {
+	if state.ResourceType.ValueString() == "DESTINATION" || state.ResourceType.ValueString() == "INSERT_DESTINATION" || state.ResourceType.ValueString() == "INSERT_SOURCE"{
 		state.DisplayName = plan.DisplayName
 	}
 


### PR DESCRIPTION
JIRA Ticket
[FUNK-1866](https://twilio-engineering.atlassian.net/browse/FUNK-1866)

### Description
This PR improves the handling of the display_name attribute for Segment Functions of type INSERT_SOURCE, INSERT_DESTINATION, and DESTINATION in the Terraform provider. Specifically, it ensures that the display_name in Terraform state remains consistent with the value provided in the configuration, avoiding unwanted workspace name suffixes that Segment may append for these resource types.

### Changes
Ensures display_name is set from the plan for INSERT_SOURCE, INSERT_DESTINATION, and DESTINATION types after create and update.
Maintains the configured display_name in the Terraform state for these types during read operations.
No changes to the provider schema or breaking changes for users.
Made changes for newly added INSERT_SOURCE tests too in _test.go
### Motivation
Segment appends the workspace name to the display name for certain function types, which can cause drift between the Terraform configuration and the actual state. This change keeps the Terraform state consistent and avoids unnecessary diffs.

### Testing
Acceptance tests for INSERT_SOURCE and other function types pass.
Manual testing with real Segment API confirms correct behavior.
![Screenshot 2025-06-26 at 8 41 32 PM](https://github.com/user-attachments/assets/39d6c4a3-b6a1-4e8e-a63f-af744055a659)
<img width="851" alt="Screenshot 2025-06-27 at 12 50 37 PM" src="https://github.com/user-attachments/assets/c2adbcbf-1638-450c-8628-55b6356f425b" />
