### PR TITLE
Bump go lang version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Segment provider allows [Terraform](https://www.terraform.io/) to manage [Se
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.21
+- [Go](https://golang.org/doc/install) >= 1.24.2
 
 ## Building The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/segmentio/terraform-provider-segment
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.2
 
 require (
 	github.com/avast/retry-go/v4 v4.6.1


### PR DESCRIPTION
Bump go lang to v1.24.2 